### PR TITLE
fix: Attempt to fix high CPU load on some laptops (issue #43)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use clap::Parser;
 use std::{cell::RefCell, rc::Rc, time::Duration};
 
 use anyhow::Context;
-use handlers::{EvDevListener, Handler, HwChangeListener};
+use handlers::{EvDevListener, Handler, HwChangeListener, SwChangeListener};
 use monitor::monitor;
 use state::State;
 
@@ -53,8 +53,12 @@ fn setup_daemon(config: &flags::Cli) -> anyhow::Result<()> {
         Led::new(config.led.clone()).context("Failed to create LED")?,
     ));
     if !config.no_adaptive_brightness {
-        if let Some(hw_path) = led.borrow().monitor_path() {
+        if let Some(hw_path) = led.borrow().hw_monitor_path() {
             listeners.push(Box::new(HwChangeListener::new(hw_path.into(), led.clone())));
+            listeners.push(Box::new(SwChangeListener::new(
+                led.borrow().sw_monitor_path(),
+                led.clone(),
+            )));
         }
     }
 

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -30,11 +30,13 @@ pub(crate) fn run_policy(
     for action in actions {
         match action {
             PolicyAction::SetLed(brightness) => {
-                led.borrow_mut().set_brightness(
-                    brightness,
-                    state,
-                    !config.no_adaptive_brightness,
-                )?;
+                if led.borrow_mut().brightness_maybe_cached()? != brightness {
+                    led.borrow_mut().set_brightness(
+                        brightness,
+                        state,
+                        !config.no_adaptive_brightness,
+                    )?;
+                }
             }
             PolicyAction::Sleep(dur) => return Ok(dur),
         }


### PR DESCRIPTION
Cache current brightness and only write if it is different:

* If hardware monitoring is supported, just cache it outright (and monitor both HW and SW files).
* If hardware monitoring is NOT supported, just cache it for 1 second.